### PR TITLE
Syntax corrections in LoopParsonsPractice, removed duplicate question

### DIFF
--- a/_sources/ArrayBasics/aMedMC.rst
+++ b/_sources/ArrayBasics/aMedMC.rst
@@ -116,27 +116,3 @@ You can step through this code with the Java Visualizer `here <http://cscircles.
      }
 
      int m = mystery(n)
-     
-.. mchoice:: qamed_5
-   :answer_a: When all values in a are larger than temp.
-   :answer_b: The values don't matter. This will always cause an infinite loop.
-   :answer_c: Whenever a has values larger than temp.
-   :answer_d: Whenever a includes a value that is less than or equal to zero.
-   :answer_e: Whenever a includes a value equal to temp.
-   :correct: d
-   :feedback_a: Values larger than temp will not cause an infinite loop.
-   :feedback_b: An infinite loop will not always occur in this program segment. It occurs when at least one value in a is less than or equal to 0.
-   :feedback_c: Values larger than temp will not cause an infinite loop.
-   :feedback_d: When a contains a value that is less than or equal to zero then multiplying that value by 2 will never make the result larger than the temp value (which was set to some value > 0), so an infinite loop will occur.
-   :feedback_e: Values equal to temp will not cause the infinite loop.
-
-   Assume that temp is an int variable intialized to be greater than zero and that a is an array of ints. What scenario will cause an infinite loop in the following code?  
-   
-   .. code-block:: java
-
-     for (int k = 0; k < a.length; k++) {
-        while (a[k] < temp) {
-           a[k] *= 2;
-        }
-     }
-

--- a/_sources/ArrayBasics/numberCubeA.rst
+++ b/_sources/ArrayBasics/numberCubeA.rst
@@ -76,7 +76,7 @@ Mixed Up Code
 -------------------
 .. parsonsprob:: NumberCubeA
 
-  The method getCubeTosses below contains the correct code for one solution to this problem, but it is mixed up and contains extra blocks that are not needed.  Drag the needed code from the left to the right and put them in order with the correct indention so that the code would work correctly.
+  The method getCubeTosses below contains the correct code for one solution to this problem, but it is mixed up.  Drag the needed code from the left to the right and put them in order with the correct indention so that the code would work correctly.
   -----
   public static int[] getCubeTosses(NumberCube cube,
                                     int numTosses)

--- a/_sources/ArrayBasics/numberCubeB.rst
+++ b/_sources/ArrayBasics/numberCubeB.rst
@@ -48,7 +48,7 @@ Mixed Up Code
 -------------------
 .. parsonsprob:: NumberCubeB
 
-  The method getLongestRun below contains the correct code for one solution to this problem, but it is mixed up and contains extra blocks that are not needed.  Drag the needed code from the left to the right and put them in order with the correct indention so that the code would work correctly.
+  The method getLongestRun below contains the correct code for one solution to this problem, but it is mixed up.  Drag the needed code from the left to the right and put them in order with the correct indention so that the code would work correctly.
   -----
   public static int getLongestRun(int[] values)
   {

--- a/_sources/LoopBasics/LoopParsonsPractice.rst
+++ b/_sources/LoopBasics/LoopParsonsPractice.rst
@@ -163,6 +163,8 @@ Try to solve each of the following. Click the *Check Me* button to check each so
    =====
                    System.out.println("*");
    =====
+               }
+           }   
        }
    }
 
@@ -184,9 +186,10 @@ Try to solve each of the following. Click the *Check Me* button to check each so
    =====
                for (int y = 0; y < x; y++) {
    =====
-                   System.out.println(x);
+                   System.out.print(x);
    =====
-               } 
+               }
+               System.out.println(); 
            }
    =====
        }
@@ -195,7 +198,7 @@ Try to solve each of the following. Click the *Check Me* button to check each so
 .. parsonsprob:: ch7ex9muc
    :noindent:
 
-   The main method in the following class should print 11111, 22222, 33333, 44444, and 55555. But, the blocks have been mixed up and contain <code>two extra blocks</code> that are not needed in a correct solution.  Drag the blocks from the left and put them in the correct order on the right.  Click the <i>Check Me</i> button to check your solution.</p>
+   The main method in the following class should print 11111, 22222, 33333, 44444, and 55555. But, the blocks have been mixed up and contain <b>two extra blocks</b> that are not needed in a correct solution.  Drag the blocks from the left and put them in the correct order on the right.  Click the <i>Check Me</i> button to check your solution.</p>
    -----
    public class Test1
    {
@@ -209,13 +212,14 @@ Try to solve each of the following. Click the *Check Me* button to check each so
    =====
                for (int y = 0; y < 5; y++) {
    =====
-                   System.out.println(x);
+                   System.out.print(x);
    =====
-                   System.out.println(y); #paired
+                   System.out.print(y); #paired
    =====
-               } 
+               } //end inner loop
+               System.out.println(); 
    =====
-           }
+           } //end outer loop
    =====
        }
    }
@@ -225,7 +229,7 @@ Try to solve each of the following. Click the *Check Me* button to check each so
 .. parsonsprob:: ch7ex10muc
    :noindent:
 
-   The main method in the following class should print 11111, 2222, 333, 44, 5.  But, the blocks have been mixed up and include <code>one extra block</code> that isn't needed in a correct solution.  Drag the needed blocks from the left and put them in the correct order on the right.  Click the <i>Check Me</i> button to check your solution.</p>
+   The main method in the following class should print 11111, 2222, 333, 44, 5.  But, the blocks have been mixed up and include <b>one extra block</b> that isn't needed in a correct solution.  Drag the needed blocks from the left and put them in the correct order on the right.  Click the <i>Check Me</i> button to check your solution.</p>
    -----
    public class Test1
    {
@@ -237,13 +241,14 @@ Try to solve each of the following. Click the *Check Me* button to check each so
    =====
                for (int y = 5; y > x; y--) {
    =====
-                   System.out.println(x+1);
+                   System.out.print(x+1);
    =====
-                   System.out.println(x); #paired
+                   System.out.print(x); #paired
    =====
-               } 
+               } //end inner loop
+               System.out.println(); 
    =====
-           }
+           } //end outer loop
    =====
        }
    }


### PR DESCRIPTION
removed duplicate question between aEasyMC and aMedMC, left the original on the Easy category because it only has 3 questions compared to Med's now 4

added necessary brackets to 7-14-7. Two opening brackets for *for* loops were never closed

removed "and contains extra blocks that are not needed" from questions whose blocks are all needed

added a "println" block to 7-14-8,9,10 to distinguish between 
"1
2
2
3
3
3"
and
"1
22
333"

changed 7-14-9,10's "extra block" to **bold** to match other questions