### PR TITLE
fix pavement configs

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -8,25 +8,29 @@ from os import environ
 
 master_url = None
 if master_url is None:
-    if gethostname() in  ['web407.webfaction.com', 'rsbuilder']:
+    if 'RSHOST' in environ:
+        master_url = environ['RSHOST']
+    elif gethostname() in  ['web407.webfaction.com', 'rsbuilder']:
         master_url = 'http://interactivepython.org'
+    elif gethostname() == 'runestone-deploy':
+        master_url = 'https://runestone.academy'
     else:
         master_url = 'http://127.0.0.1:8000'
 
 master_app = 'runestone'
-serving_dir = "./build/JavaReview"
+serving_dir = "./build/apcsareview"
 dest = '../../static'
 
 options(
     sphinx = Bunch(docroot=".",),
 
     build = Bunch(
-        builddir="./build/JavaReview",
+        builddir="./build/apcsareview",
         sourcedir="_sources",
-        outdir="./build/JavaReview",
+        outdir="./build/apcsareview",
         confdir=".",
-        project_name = "JavaReview",
-        template_args={'course_id': 'JavaReview',
+        project_name = "apcsareview",
+        template_args={'course_id': 'apcsareview',
                        'login_required':'false',
                        'appname':master_app,
                        'loglevel': 10,
@@ -34,7 +38,7 @@ options(
                        'use_services': 'true',
                        'python3': 'false',
                        'dburl': 'postgresql://runestone@localhost/runestone',
-                       'basecourse': 'javareview'
+                       'basecourse': 'apcsareview'
                         }
     )
 )


### PR DESCRIPTION
These are all of the changes needed to make this work on runestone academy.  The base course name needs to match the value we use on the website course building page, and of course we need to detect and set the right.